### PR TITLE
Add ActiveRecord request params to binds hash

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/extensions/active_record/log_subscriber.rb
@@ -32,7 +32,8 @@ module ActiveRecord
         elsif Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR <= 1 && (Rails::VERSION::MINOR == 0 || Rails::VERSION::TINY <= 4) # 5.0.3 - 5.1.4
           casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
           payload[:binds].zip(casted_params).map { |attr, value|
-            render_bind(attr, value)
+            attr_name, value = render_bind(attr, value)
+            binds[attr_name] = value
           }
         elsif Rails::VERSION::MAJOR >= 5 # >= 5.1.5
           casted_params = type_casted_binds(payload[:type_casted_binds])


### PR DESCRIPTION
Checked on Rails 5.1.3
Before changes not put query params in binds hash
Maybe the same fix need to condition 'Rails::VERSION::MAJOR >= 5 # >= 5.1.5'